### PR TITLE
fix(renovate): use array of strings for descriptions

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -3,61 +3,75 @@
   "extends": [
     // Base configuration
     "config:best-practices",
-
     // Add "Signed-off-by" footer to commit messages
     ":gitSignOff",
-
     // Catch-all for grouping dependencies not caught by other groups
     "group:all"
   ],
-
   // Rebase when there are merge conflicts
   //
   // The "conflicted" option is typically the ideal choice for most situations
   // where you don't want to burn CI credits, while still keeping your branch
   // in a mergeable state at all times.
   "rebaseWhen": "conflicted",
-
   "packageRules": [
     // Group GitHub Actions dependencies
     {
-      "description": "GitHub Actions dependencies",
-      "matchManagers": ["github-actions"],
+      "description": [
+        "GitHub Actions dependencies"
+      ],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "GitHub Actions",
       "enabled": true
     },
-
     // Group Rust dependencies
     {
-      "description": "Rust dependencies",
-      "matchManagers": ["cargo"],
+      "description": [
+        "Rust dependencies"
+      ],
+      "matchManagers": [
+        "cargo"
+      ],
       "groupName": "Rust",
       "enabled": true
     },
-
     // Group Docker dependencies
     {
-      "description": "Docker dependencies",
-      "matchManagers": ["dockerfile"],
+      "description": [
+        "Docker dependencies"
+      ],
+      "matchManagers": [
+        "dockerfile"
+      ],
       "groupName": "Docker",
       "enabled": true
     },
-
     // Disable Containerfile digest pinning
     {
-      "description": "Containerfile digest pinning",
-      "matchManagers": ["dockerfile"],
+      "description": [
+        "Containerfile digest pinning"
+      ],
+      "matchManagers": [
+        "dockerfile"
+      ],
       "pinDigests": false
     },
-
     // Disable Fedora OCI updates
     //
     // This is due to there not being an easy way to tell Renovate which
     // Fedora version is "stable" and which has not been released yet.
     {
-      "description": "Disable Fedora OCI updates",
-      "matchManagers": ["dockerfile"],
-      "matchDepNames": ["quay.io/fedora/fedora"],
+      "description": [
+        "Disable Fedora OCI updates"
+      ],
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchDepNames": [
+        "quay.io/fedora/fedora"
+      ],
       "enabled": false
     }
   ]


### PR DESCRIPTION
(should) Fix #13 

I'm not entirely sure why it was complaining about being a string, when ALL documentation show description being a string except [one section](https://docs.renovatebot.com/configuration-options/#description).  

I've ran this through the Renovate config validator and it's successful, though it was successful prior to this patch.