### PR TITLE
config: use recommended preset rather than best-practices

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     // Base configuration
-    "config:best-practices",
+    "config:recommended",
     // Add "Signed-off-by" footer to commit messages
     ":gitSignOff",
     // Catch-all for grouping dependencies not caught by other groups


### PR DESCRIPTION
Closes #16 

The `config:recommended` preset removes things like dependency pinning, and focusing solely on updates.  Seems like a better starting point rather than the more opinionated `config:best-practices` preset.

We can add back the more opinionated rules one-by-one at a later date if we wish.