### PR TITLE
fix: prevent dependency management of Fedora OCI images

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -68,10 +68,12 @@
         "Disable Fedora OCI updates"
       ],
       "matchManagers": [
-        "dockerfile"
+        "dockerfile",
+        "github-actions"
       ],
       "matchDepNames": [
-        "quay.io/fedora/fedora"
+        "quay.io/fedora/fedora",
+        "quay.io/fedora/fedora-bootc"
       ],
       "enabled": false
     }


### PR DESCRIPTION
Renovate is not aware of how to version Fedora OCI images, and always attempts to upgrade to pre-release versions (currently 43).

Disable management of all quay.io/fedora/fedora and quay.io/fedora/fedora-bootc.