### PR TITLE
fix(ci): remove pull_request renovate workflow trigger

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,9 +10,6 @@ on:
         options:
           - info
           - debug
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: '3 * * * *'
 jobs:


### PR DESCRIPTION
This workflow does not have access to the required secrets to invoke Renovate, so it always errors out.