### PR TITLE
fix(ci): use apps.getAuthenticated() for GitHub App tokens

### DIFF
--- a/.github/workflows/sync-common.yml
+++ b/.github/workflows/sync-common.yml
@@ -103,10 +103,12 @@ jobs:
         with:
           github-token: ${{ steps.token.outputs.token }}
           script: |
-            const user = await github.rest.users.getAuthenticated();
-            console.log('Bot user:', user.data);
-            core.setOutput('name', user.data.login);
-            core.setOutput('email', `${user.data.id}+${user.data.login}@users.noreply.github.com`);
+            const app = await github.rest.apps.getAuthenticated();
+            console.log('Bot app:', app.data);
+            const botName = `${app.data.slug}[bot]`;
+            const botEmail = `${app.data.id}+${app.data.slug}[bot]@users.noreply.github.com`;
+            core.setOutput('name', botName);
+            core.setOutput('email', botEmail);
 
       - name: Sync common files to repository
         run: |


### PR DESCRIPTION
The workflow was failing with "Resource not accessible by integration" because GitHub App tokens cannot access the /user endpoint. That endpoint is only available for OAuth tokens. Changed to use apps.getAuthenticated() which returns the app information and works correctly with GitHub App tokens.

Assisted-by: Claude Code (Sonnet 4.5)