### PR TITLE
Fix Renovate configuration validation errors

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Validate Renovate config
+        run: |
+          docker run --rm -v "$PWD:/repo" -w /repo \
+            ghcr.io/renovatebot/renovate:41 \
+            renovate-config-validator renovate-shared-config.json
+
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v43.0.10
         env:

--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -15,8 +15,9 @@
   // where you don't want to burn CI credits, while still keeping your branch
   // in a mergeable state at all times.
   "rebaseWhen": "conflicted",
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["(^|/)Containerfile$", "(^|/)Dockerfile$"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+ARG \\w+version=(?<currentValue>.+)"
@@ -47,7 +48,7 @@
       "description": "Docker dependencies",
       "matchManagers": [
         "dockerfile",
-        "regex"
+        "custom.regex"
       ],
       "groupName": "Docker",
       "enabled": true


### PR DESCRIPTION
The previous commit incorrectly changed customManagers to regexManagers, which caused configuration validation errors. Renovate expects:
- customManagers with customType: "regex" (not regexManagers)
- custom.regex as the manager name in packageRules (not just "regex")

This restores the correct configuration format that validates successfully.

Fixes: de7e68e ("Fix Renovate configuration errors (#33)")

Assisted-by: Claude Code (Sonnet 4.5)