### PR TITLE
action: Add setup-rust composite action

### DIFF
--- a/common/.github/actions/bootc-ubuntu-setup/action.yml
+++ b/common/.github/actions/bootc-ubuntu-setup/action.yml
@@ -61,16 +61,6 @@ runs:
       id: set_arch
       shell: bash
       run: echo "ARCH=$(arch)" >> $GITHUB_ENV
-    # We often use Rust, so set up opinionated default caching
-    - name: Setup Rust cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        cache-all-crates: true
-        # Only generate caches on push to git main
-        save-if: ${{ github.ref == 'refs/heads/main' }}
-        # Suppress actually using the cache for builds running from
-        # git main so that we avoid incremental compilation bugs
-        lookup-only: ${{ github.ref == 'refs/heads/main' }}
     # Install libvirt stack if requested
     - name: Install libvirt and virtualization stack
       if: ${{ inputs.libvirt == 'true' }}

--- a/common/.github/actions/setup-rust/action.yml
+++ b/common/.github/actions/setup-rust/action.yml
@@ -1,0 +1,20 @@
+name: 'Setup Rust'
+description: 'Install Rust toolchain with caching and nextest'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+    - name: Install nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
+    - name: Setup Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        cache-all-crates: true
+        # Only generate caches on push to git main
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+        # Suppress actually using the cache for builds running from
+        # git main so that we avoid incremental compilation bugs
+        lookup-only: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This creates a reusable composite action for setting up Rust in CI workflows. It installs the Rust toolchain, nextest, and configures caching with Swatinem/rust-cache.

This is moved out of the bootc-ubuntu-setup action because we shouldn't hardcode one thing specific to Rust there.

Assisted-by: Claude Code (Sonnet 4.5)