### PR TITLE
common: Add rebase workflow

### DIFF
--- a/common/.github/workflows/rebase.yml
+++ b/common/.github/workflows/rebase.yml
@@ -1,0 +1,45 @@
+name: Automatic Rebase
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.label.name == 'needs-rebase'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Actions Token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Automatic Rebase
+        uses: peter-evans/rebase@v3
+        with:
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Remove needs-rebase label
+        if: always()
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.token.outputs.token }}
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'needs-rebase'
+            });


### PR DESCRIPTION
Add automatic rebase workflow that triggers when the needs-rebase label is added to a pull request. This provides a secure way to trigger rebases since only users with triage or write permissions can add labels.

The workflow uses the app token for permissions and removes the label after the rebase attempt completes.

Assisted-by: Claude Code (Sonnet 4.5)