### PR TITLE
Fix label sync workflow JSON parsing

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -113,10 +113,12 @@ jobs:
 
       - name: Sync labels
         uses: actions/github-script@v8
+        env:
+          LABELS_JSON: ${{ needs.init.outputs.labels }}
         with:
           github-token: ${{ steps.token.outputs.token }}
           script: |
-            const labels = ${{ fromJSON(needs.init.outputs.labels) }};
+            const labels = JSON.parse(process.env.LABELS_JSON);
             const owner = context.repo.owner;
             const repo = '${{ matrix.repo }}';
 


### PR DESCRIPTION
Fixes https://github.com/bootc-dev/infra/pull/47

(hopefully)

I mean I gotta say, on one hand it's cool I can use AI to just magic up workflow and CI things I want instead of trying to figure out which of the 20 marketplace actions are safe to use and do what I want.

On the other hand AI so easily screws things up with dynamic languages - this Javascript-in-YAML being a perfect example.

---

Pass labels JSON via environment variable and parse with JSON.parse() instead of using fromJSON() inline in the script. The fromJSON() function doesn't work correctly when used inline in github-script blocks.

This fixes the workflow failure where labels was being set to `Array` instead of the actual array contents.

Assisted-by: Claude Code (Sonnet 4.5)