### PR TITLE
ci: Fix sync-common workflow

### DIFF
--- a/.github/workflows/sync-common.yml
+++ b/.github/workflows/sync-common.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./common/.github/actions/setup-rust
 
       - name: Build sync-common
         run: cargo build --release --manifest-path scripts/sync-common/Cargo.toml


### PR DESCRIPTION
GHA apparently doesn't follow symlinks for actions.