### PR TITLE
renovate: Ignore bootc cargo dependency checkout

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -82,6 +82,17 @@
         "quay.io/fedora/fedora-bootc"
       ],
       "enabled": false
+    },
+    // Ignore bootc cargo dependencies to fix failing Renovate task
+    // See: https://github.com/bootc-dev/infra/actions/runs/19914695687
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": [
+        "composefs",
+        "composefs-boot",
+        "composefs-oci"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Fix renovate task failure https://github.com/bootc-dev/infra/actions/runs/19914695687/job/57090900822.