### PR TITLE
renovate: Add config to scan common/ for GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>bootc-dev/infra:renovate-shared-config.json"
+  ],
+  "github-actions": {
+    "fileMatch": [
+      "(^|/).github/workflows/[^/]+\\.ya?ml$",
+      "(^|/).github/actions/[^/]+/action\\.ya?ml$"
+    ]
+  }
+}


### PR DESCRIPTION
Renovate was updating GitHub Actions versions in target repositories but not in the common/ directory of this infra repo. This created a reconciliation loop where sync-common would overwrite Renovate's updates with older versions from common/.

Add renovate.json with explicit fileMatch patterns for the github-actions manager to scan both workflows and composite actions under common/.github/.

Fixes: https://github.com/bootc-dev/bootc/pull/1865#discussion_r2628706060

Assisted-by: OpenCode (Sonnet 4)