### PR TITLE
renovate: ignore policy workflows and internal actions in all repos except infra

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -31,6 +31,23 @@
     }
   ],
   "packageRules": [
+    {
+    // These files in these repos are synced from the bootc-dev/infra repository, which
+    // sends PRs to update them. Ignoring them here to avoid conflicting Renovate updates.
+      "matchRepositories": [
+        "bootc-dev/bootc",
+        "bootc-dev/bcvk",
+        "bootc-dev/ci-sandbox",
+        "bootc-dev/containers-image-proxy-rs",
+        "bootc-dev/bootc-dev.github.io"
+      ],
+      "ignorePaths": [
+        ".github/workflows/rebase.yml",
+        ".github/workflows/openssf-scorecard.yml",
+        ".github/actions/bootc-ubuntu-setup/action.yml",
+        ".github/actions/setup-rust/action.yml"
+      ]
+    },
     // Group GitHub Actions dependencies
     {
       "description": ["GitHub Actions dependencies"],


### PR DESCRIPTION
Add a packageRules entry in renovate-shared-config.json to exclude the following files from Renovate updates across all bootc-dev repositories except 'infra':
- .github/workflows/rebase.yml
- .github/workflows/openssf-scorecard.yml
- .github/actions/bootc-ubuntu-setup/action.yml
- .github/actions/setup-rust/action.yml

This ensures policy-managed workflows and internal composite actions are not modified automatically while keeping infra repo fully manageable.