### PR TITLE
renovate: Look for updates to *.txt for dependencies

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -28,6 +28,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+ARG \\w+version=(?<currentValue>.+)"
       ]
+    },
+    // Match "# renovate:" comments in .txt files followed by package@version on next line
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["\\.txt$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\n.*@(?<currentValue>\\S+)"
+      ]
     }
   ],
   "packageRules": [
@@ -73,7 +81,15 @@
         "dockerfile",
         "custom.regex"
       ],
+      "excludeDatasources": ["npm"],
       "groupName": "Docker",
+      "enabled": true
+    },
+    // Group npm dependencies
+    {
+      "description": ["npm dependencies"],
+      "matchDatasources": ["npm"],
+      "groupName": "npm",
       "enabled": true
     },
     // Disable Containerfile digest pinning


### PR DESCRIPTION
This should hopefully pick up updates for opencode which lives in npm.txt.