### PR TITLE
renovate: Remove invalid excludeDatasources field

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -84,7 +84,6 @@
         "dockerfile",
         "custom.regex"
       ],
-      "excludeDatasources": ["npm"],
       "groupName": "Docker",
       "enabled": true
     },


### PR DESCRIPTION
`excludeDatasources` is not a valid `packageRules` option. The npm rule already takes precedence due to its specificity (`matchDatasources`), so this exclusion was both invalid and unnecessary.

Ref: https://docs.renovatebot.com/configuration-options/ 
Fixes #71