### PR TITLE
devenv: Add bubblewrap for sandboxing support

### DIFF
--- a/devenv/packages-common.txt
+++ b/devenv/packages-common.txt
@@ -9,6 +9,9 @@ sudo
 acl
 rsync
 
+# Sandboxing (used by devaipod and flatpak)
+bubblewrap
+
 # General build env (note: we install rust through rustup later)
 gcc
 clang


### PR DESCRIPTION
bubblewrap (bwrap) is needed for running sandboxed environments like devaipod and flatpak. The package name is the same on both Debian and CentOS/RHEL.