### PR TITLE
renovate: Fix custom manager pattern for .txt files

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -35,7 +35,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["\\.txt$"],
+      "managerFilePatterns": ["**/*.txt"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\n.*@(?<currentValue>\\S+)"
       ]


### PR DESCRIPTION
The managerFilePatterns value '\.txt$' was not being recognized as a regex pattern by Renovate's file matching logic. Regex patterns need to be wrapped in forward slash delimiters (e.g., '/\.txt$/') to be recognized, otherwise they may be interpreted as glob patterns.

Changed to glob pattern '**/*.txt' which correctly matches all .txt files in any subdirectory, enabling Renovate to detect and update dependencies like opencode-ai in devenv/npm.txt.

References for managerFilePatterns syntax:
- renovatebot/.github uses '/\.md$/' for regex patterns
- copier-org/copier uses '**/*' for glob patterns
- gotify/server uses '/^go.mod$/' for regex patterns

Assisted-by: OpenCode (Claude Sonnet 4)