### PR TITLE
Two patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ This repository provides centralized configuration and automation for the
 
 - **[Development Environment](devenv/README.md)** - Containerized dev environment with
   necessary tools
-- **[Renovate](#renovate)** - Centralized dependency update management
-- **Container Garbage Collection** - Automated cleanup of old images from GHCR
+- **Scheduled Global Actions** - Automation that runs across the organization:
+  - [Renovate](#renovate) - Centralized dependency update management
+  - Container Garbage Collection - Automated cleanup of old images from GHCR
+
+## Documentation
+
+- [New Repository Setup](docs/SOP-new-repository.md) - Steps for onboarding new repos
 
 ## Renovate
 

--- a/docs/SOP-new-repository.md
+++ b/docs/SOP-new-repository.md
@@ -1,0 +1,63 @@
+# Standard Operating Procedure: New Repository Setup
+
+This document describes the steps required when creating a new repository in the
+bootc-dev organization.
+
+## 1. Add the Maintainers Team
+
+All repositories should grant the `maintainers` team **Maintain** permission.
+This provides consistent access for organization maintainers across all repos.
+
+To add the team via `gh`:
+
+```sh
+gh api -X PUT repos/bootc-dev/<REPO_NAME>/teams/maintainers \
+  -f permission=maintain
+```
+
+Or via the GitHub web UI:
+1. Go to the repository Settings
+2. Navigate to Collaborators and teams
+3. Click "Add teams"
+4. Search for "maintainers"
+5. Select "Maintain" as the role
+
+## 2. Configure Renovate
+
+The organization uses a centralized Renovate configuration managed from this
+repository. To enable Renovate on a new repository, create a `renovate.json`
+file in the repository root:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>bootc-dev/infra:renovate-shared-config.json"
+  ]
+}
+```
+
+This inherits all shared configuration including:
+- Recommended base config with signed-off commits
+- GitHub Actions, Rust, Docker, and npm dependency detection
+- Dependency grouping by ecosystem
+- Custom managers for Containerfiles and txt files
+- Disabled Fedora OCI updates and digest pinning
+
+### Repository-Specific Overrides
+
+If synced workflow files are used (rebase.yml, openssf-scorecard.yml, etc.),
+add the repository to the `ignorePaths` rule in
+[renovate-shared-config.json](renovate-shared-config.json) to avoid
+conflicting updates.
+
+## 3. Post-Setup Verification
+
+After setup, verify:
+- [ ] `maintainers` team appears in Settings > Collaborators and teams with Maintain role
+- [ ] `renovate.json` exists and passes validation
+- [ ] Renovate creates initial dependency update PRs (may take up to 24h or trigger manually)
+
+To manually trigger Renovate, run the workflow from the
+[Actions tab](https://github.com/bootc-dev/infra/actions/workflows/renovate.yml)
+in this repository.


### PR DESCRIPTION
README: Simplify and consolidate content

Remove verbose sections and redundant explanations. Consolidate the
table of contents into a concise 'What's Here' section. Trim the
Renovate documentation to essential information while keeping the
config example for maintainers.

Assisted-by: OpenCode (Claude Sonnet 4)
Signed-off-by: Colin Walters <walters@verbum.org>

---

docs: Add SOP for new repository setup

Document the standard steps for onboarding new repositories:
- Adding the maintainers team with Maintain permission
- Configuring Renovate to inherit the shared config
- Post-setup verification checklist

Assisted-by: OpenCode (Claude Sonnet 4)
Signed-off-by: Colin Walters <walters@verbum.org>

---
