### PR TITLE
renovate: Add 1 week minimumReleaseAge for dependency updates

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -42,6 +42,24 @@
     }
   ],
   "packageRules": [
+    // Default: Wait 1 week before proposing updates to ensure stability
+    //
+    // This prevents chasing every patch release and reduces PR noise from
+    // rapidly-updating dependencies (e.g., opencode-ai had 7 updates in 8 days).
+    {
+      "description": ["Wait 1 week before proposing updates to ensure stability"],
+      "matchPackageNames": ["/.*/"],
+      "minimumReleaseAge": "7 days"
+    },
+    // Exceptions: Pick up certain packages immediately
+    //
+    // Add rules here for packages that should bypass the default waiting period,
+    // such as our own projects or critical dependencies.
+    {
+      "description": ["Pick up bcvk packages immediately without waiting"],
+      "matchPackageNames": ["/^bcvk$/"],
+      "minimumReleaseAge": "0 days"
+    },
     {
     // These files in these repos are synced from the bootc-dev/infra repository, which
     // sends PRs to update them. Ignoring them here to avoid conflicting Renovate updates.


### PR DESCRIPTION
Reduce PR noise from rapidly-updating dependencies by waiting 1 week before proposing updates. Analysis showed some packages (e.g., opencode-ai) had 7 updates in 8 days, creating excessive churn.

Exceptions can be added for packages that should bypass the waiting period, such as our own projects (bcvk) or critical dependencies.

Assisted-by: OpenCode (Claude Sonnet 4)