### PR TITLE
renovate: Add git-refs custom manager for commit SHA tracking

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -47,6 +47,21 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\n\\s*VERSION=(?<currentValue>v?\\S+)"
       ]
+    },
+    // Git refs (commit SHA) tracking in Justfiles and YAML workflows
+    // Justfile example:
+    //   # renovate: datasource=git-refs depName=https://github.com/org/repo branch=main
+    //   export VAR := env("VAR", "0000000000000000000000000000000000000000")
+    // YAML example:
+    //   # renovate: datasource=git-refs depName=https://github.com/org/repo branch=main
+    //   VAR: '0000000000000000000000000000000000000000'
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["**/Justfile", "**/*.just", "**/*.yml", "**/*.yaml"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>git-refs) depName=(?<depName>[^\\s]+) branch=(?<currentValue>[^\\s]+)\\n[^\\n]*\"(?<currentDigest>[a-f0-9]{40})\"",
+        "# renovate: datasource=(?<datasource>git-refs) depName=(?<depName>[^\\s]+) branch=(?<currentValue>[^\\s]+)\\n[^\\n]*'(?<currentDigest>[a-f0-9]{40})'"
+      ]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Add a custom regex manager to track git commit SHAs in GitHub Actions workflow files. The pattern matches:

```
  # renovate: datasource=git-refs depName=https://github.com/org/repo branch=main
  VAR: '1234abcd...'
```

This enables renovate to automatically update pinned commit references when the tracked branch (e.g., main) advances.

Assisted-by: Claude Sonnet 4 (via OpenCode)