### PR TITLE
devenv: Make init script more robust for devpod environments

### DIFF
--- a/devenv/devenv-init.sh
+++ b/devenv/devenv-init.sh
@@ -1,14 +1,26 @@
 #!/bin/bash
 set -euo pipefail
 # Set things up so that podman can run nested inside the privileged
-# docker container of a codespace.
+# docker container of a codespace or devpod.
 
-# Fix the propagation
-sudo mount -o remount --make-shared /
+# Fix the propagation - only needed in some environments (e.g., codespaces)
+# In devpod with rootless podman, / may already have shared propagation
+# or we may not have permission to remount it.
+propagation=$(findmnt -J -o TARGET,PROPAGATION / | jq -r '.filesystems[0].propagation // "unknown"')
+if [ "$propagation" = "private" ]; then
+    if mount -o remount --make-shared / 2>/dev/null; then
+        echo "Set / to shared propagation"
+    else
+        echo "Warning: Could not set / to shared propagation (may not be needed)"
+    fi
+fi
 
 # This is actually safe to expose to all users really, like Fedora derivatives do
-chmod a+rw /dev/kvm
+if [ -e /dev/kvm ]; then
+    chmod a+rw /dev/kvm 2>/dev/null || true
+fi
 
-# Handle nested cgroups
-sed -i -e 's,^#cgroups =.*,cgroups = "no-conmon",' /usr/share/containers/containers.conf
-sed -i -e 's,^#cgroup_manager =.*,cgroup_manager = "cgroupfs",' /usr/share/containers/containers.conf
+# Handle nested cgroups - update containers.conf if it exists and has the settings commented out
+if [ -f /usr/share/containers/containers.conf ]; then
+    sed -i -e 's,^#cgroups =.*,cgroups = "no-conmon",' -e 's,^#cgroup_manager =.*,cgroup_manager = "cgroupfs",' /usr/share/containers/containers.conf
+fi

--- a/devenv/packages-common.txt
+++ b/devenv/packages-common.txt
@@ -12,6 +12,9 @@ rsync
 # Sandboxing (used by devaipod and flatpak)
 bubblewrap
 
+# Terminal multiplexer (used by devaipod tmux command)
+tmux
+
 # General build env (note: we install rust through rustup later)
 gcc
 clang


### PR DESCRIPTION
The remount --make-shared / only works in codespaces which have specific Docker privileges. In devpod with rootless podman, the root filesystem may already have shared propagation or we may not have permission to remount.

Use findmnt -J with jq for proper JSON parsing instead of string grep.

Also add guards for:
- /dev/kvm which may not exist in all environments
- /usr/share/containers/containers.conf which may not exist

Additionally, add tmux to common packages (used by devaipod's tmux command for split-view agent+shell sessions).

Assisted-by: OpenCode (Claude sonnet-4-20250514)