### PR TITLE
renovate: Use default rebaseWhen instead of conflicted

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -15,12 +15,6 @@
   // referenced in Cargo.toml files. Without initializing submodules, Renovate
   // will fail to analyze these dependencies.
   "cloneSubmodules": true,
-  // Rebase when there are merge conflicts
-  //
-  // The "conflicted" option is typically the ideal choice for most situations
-  // where you don't want to burn CI credits, while still keeping your branch
-  // in a mergeable state at all times.
-  "rebaseWhen": "conflicted",
   // Custom managers for detecting dependencies in non-standard files
   //
   // - Containerfile/Dockerfile: Match "# renovate:" comments with ARG statements


### PR DESCRIPTION
Remove the explicit rebaseWhen=conflicted override to use Renovate's default of 'auto'.

The 'conflicted' setting was causing issues where Renovate would update PR titles and descriptions to show newer available versions, but would not actually push new commits to update the branch contents. This led to confusing PRs like homebrew-bcvk#3 where the PR says 'v0.5.3 → v0.9.0' but the code only updates to v0.6.0.

Assisted-by: OpenCode (Opus 4.5)