### PR TITLE
devenv: Disable apt sandboxing in nested containers

### DIFF
--- a/devenv/Containerfile.debian
+++ b/devenv/Containerfile.debian
@@ -7,6 +7,9 @@ RUN ln -sfr /bin/bash /bin/sh
 RUN <<EORUN
 set -xeuo pipefail
 
+# Disable apt sandboxing for nested container environments
+echo 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/99sandbox-disable
+
 # Initialize some basic packages
 apt -y update && apt -y install curl time bzip2
 


### PR DESCRIPTION
Add APT::Sandbox::User "root" configuration to prevent setgroups failures when running apt in nested user namespace environments.

This fixes apt package installation failures that occur when the container's user namespace mapping causes large UIDs/GIDs that exceed system limits.

Assisted-by: OpenCode (Sonnet 4.5)