### PR TITLE
devenv: Install pinned nightly Rust toolchain via rustup

### DIFF
--- a/devenv/Containerfile.c10s
+++ b/devenv/Containerfile.c10s
@@ -39,8 +39,10 @@ RUN bcvkversion=$bcvkversion scorecardversion=$scorecardversion nushellversion=$
 RUN uvversion=$uvversion /run/src/install-uv.sh
 
 FROM base as rust
+# renovate: datasource=custom.rust-nightly depName=rust-nightly versioning=rust-release-channel
+ARG rust_nightly=nightly-2026-03-02
 COPY install-rust.sh /run/src/
-RUN /run/src/install-rust.sh
+RUN rust_nightly=$rust_nightly /run/src/install-rust.sh
 
 # Kani formal verification tool - requires rustup for toolchain management
 FROM rust as kani

--- a/devenv/Containerfile.debian
+++ b/devenv/Containerfile.debian
@@ -42,8 +42,10 @@ RUN bcvkversion=$bcvkversion scorecardversion=$scorecardversion nushellversion=$
 RUN uvversion=$uvversion /run/src/install-uv.sh
 
 FROM base as rust
+# renovate: datasource=custom.rust-nightly depName=rust-nightly versioning=rust-release-channel
+ARG rust_nightly=nightly-2026-03-02
 COPY install-rust.sh /run/src/
-RUN /run/src/install-rust.sh
+RUN rust_nightly=$rust_nightly /run/src/install-rust.sh
 
 # Kani formal verification tool - requires rustup for toolchain management
 FROM rust as kani

--- a/devenv/install-rust.sh
+++ b/devenv/install-rust.sh
@@ -9,6 +9,15 @@ export CARGO_HOME=/usr/local/cargo
 # Install Rust system-wide
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile default
 
+# Install nightly toolchain if requested (pinned date, e.g. nightly-2026-03-02)
+if [ -n "${rust_nightly:-}" ]; then
+  /usr/local/cargo/bin/rustup toolchain install "${rust_nightly}" --profile minimal
+  # Symlink the dated nightly as "nightly" so `cargo +nightly` works without
+  # requiring write access to RUSTUP_HOME for channel updates.
+  host=$(/usr/local/cargo/bin/rustc --print host-tuple)
+  ln -sf "${rust_nightly}-${host}" "$RUSTUP_HOME/toolchains/nightly-${host}"
+fi
+
 # Move binaries to /usr/local/bin (system-managed, root-owned)
 mv /usr/local/cargo/bin/* /usr/local/bin/
 

--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -15,6 +15,19 @@
   // referenced in Cargo.toml files. Without initializing submodules, Renovate
   // will fail to analyze these dependencies.
   "cloneSubmodules": true,
+  // Custom datasource for tracking Rust nightly toolchain releases via the
+  // official release manifest. This is the same data source the upcoming
+  // native rust-version datasource (renovatebot/renovate#39529) will use;
+  // once that merges this can be replaced with zero-config native support.
+  "customDatasources": {
+    "rust-nightly": {
+      "defaultRegistryUrlTemplate": "https://static.rust-lang.org/manifests.txt",
+      "format": "plain",
+      "transformTemplates": [
+        "{ \"releases\": $filter(releases, function($r) { $contains($r.version, \"channel-rust-nightly.toml\") }).$merge([{ \"version\": \"nightly-\" & $match(version, /(\\d{4}-\\d{2}-\\d{2})/).groups[0] }]) }"
+      ]
+    }
+  },
   // Custom managers for detecting dependencies in non-standard files
   //
   // - Containerfile/Dockerfile: Match "# renovate:" comments with ARG statements
@@ -24,7 +37,8 @@
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)Containerfile(\\.[^/]*)?$/", "/(^|/)Dockerfile(\\.[^/]*)?$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+ARG \\w+version=(?<currentValue>.+)"
+        "# renovate: datasource=(?<datasource>[a-z.-]+) depName=(?<depName>[^\\s]+)\\s+ARG \\w+version=(?<currentValue>.+)",
+        "# renovate: datasource=(?<datasource>[a-z.-]+) depName=(?<depName>[^\\s]+) versioning=(?<versioning>[^\\s]+)\\s+ARG \\w+=(?<currentValue>.+)"
       ]
     },
     {
@@ -159,6 +173,11 @@
         "composefs-oci"
       ],
       "enabled": false
+    },
+    // Rust nightly toolchain: use rust-release-channel versioning for nightly-YYYY-MM-DD format
+    {
+      "matchDatasources": ["custom.rust-nightly"],
+      "versioning": "rust-release-channel"
     }
   ]
 }


### PR DESCRIPTION
I want to start using `cargo fuzz`; it requires a nightly toolchain per https://rust-fuzz.github.io/book/cargo-fuzz/setup.html

Pin to a version that gets renovate-bumped.
(In the future I'd like to CI gate that our devenv works on
 some representative projects)

Renovate is configured to track new nightlies via a custom datasource that reads the official Rust release manifest (manifests.txt), using the rust-release-channel versioning scheme. This is the same data source the upcoming native rust-version datasource will use (renovatebot/renovate#39529); once that merges this custom config can be replaced with zero-config native support.

Tested: `podman run <image> cargo +nightly --version` succeeds in the resulting c10s container image.

Assisted-by: OpenCode (Claude claude-opus-4-6)