### PR TITLE
staged-images: Fix duplicate sources, switch to coreos/chunkah

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -186,20 +186,23 @@
       ],
       "pinDigests": false
     },
-    // Disable Fedora OCI updates
+    // Disable Fedora OCI tag updates
     //
-    // This is due to there not being an easy way to tell Renovate which
-    // Fedora version is "stable" and which has not been released yet.
+    // Renovate can't distinguish stable vs unreleased Fedora versions,
+    // so we disable tag bumps. Digest-only updates are still allowed
+    // via the separate rule below.
     {
-      "description": ["Disable Fedora OCI updates"],
+      "description": ["Disable Fedora OCI tag updates (can't distinguish stable vs unreleased)"],
       "matchManagers": [
         "dockerfile",
-        "github-actions"
+        "github-actions",
+        "custom.regex"
       ],
       "matchDepNames": [
         "quay.io/fedora/fedora",
         "quay.io/fedora/fedora-bootc"
       ],
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "enabled": false
     },
     // Ignore bootc cargo dependencies to fix failing Renovate task

--- a/staged-images/Containerfile
+++ b/staged-images/Containerfile
@@ -8,7 +8,7 @@
 # Usage: just staged-images/build fedora-bootc-44
 
 ARG SOURCE_IMAGE
-ARG CHUNKAH=quay.io/jlebon/chunkah:latest
+ARG CHUNKAH=quay.io/coreos/chunkah:latest
 ARG MAX_LAYERS=128
 
 FROM ${SOURCE_IMAGE} AS source

--- a/staged-images/Justfile
+++ b/staged-images/Justfile
@@ -2,14 +2,15 @@ _sources := justfile_directory() / "sources.json"
 registry := env("REGISTRY", "ghcr.io")
 registry_owner := env("REGISTRY_OWNER", "bootc-dev")
 
-# Look up a field from sources.json by image key (e.g. fedora-bootc-43)
+# Look up a field from sources.json by image key (e.g. fedora-bootc-43).
+# Errors if the key matches zero or more than one entry.
 [private]
 _field image field:
-	@jq -re --arg n "{{image}}" '.[] | select(.name + "-" + .tag == $n) | .{{field}}' "{{_sources}}"
+	@jq -re --arg n "{{image}}" '[.[] | select(.name + "-" + .tag == $n)] | if length != 1 then error("expected exactly 1 match for \($n), got \(length)") else .[0].{{field}} end' "{{_sources}}"
 
 # List available staged images
 list:
-	@jq -r '.[] | .name + "-" + .tag' "{{_sources}}"
+	@jq -r '[.[] | .name + "-" + .tag] | unique | .[]' "{{_sources}}"
 
 # Mirror an upstream source image to our registry.
 # Usage: just staged-images/mirror fedora-bootc-43
@@ -63,7 +64,7 @@ build image:
 build-all:
 	#!/bin/bash
 	set -euo pipefail
-	for image in $(jq -r '.[] | .name + "-" + .tag' "{{_sources}}"); do
+	for image in $(jq -r '[.[] | .name + "-" + .tag] | unique | .[]' "{{_sources}}"); do
 	  just {{justfile_directory()}}/build "$image"
 	done
 
@@ -92,10 +93,10 @@ push image arch="":
 # Generate GHA matrices from sources.json (used by CI workflow)
 [private]
 ci-matrix:
-	@jq -c '[.[] | . as $img | {name: ($img.name + "-staged"), tag: $img.tag, image_key: ($img.name + "-" + $img.tag), arch: "amd64", runner: "ubuntu-24.04"}, {name: ($img.name + "-staged"), tag: $img.tag, image_key: ($img.name + "-" + $img.tag), arch: "arm64", runner: "ubuntu-24.04-arm"}] | {include: .}' "{{_sources}}"
+	@jq -c '[.[] | . as $img | {name: ($img.name + "-staged"), tag: $img.tag, image_key: ($img.name + "-" + $img.tag), arch: "amd64", runner: "ubuntu-24.04"}, {name: ($img.name + "-staged"), tag: $img.tag, image_key: ($img.name + "-" + $img.tag), arch: "arm64", runner: "ubuntu-24.04-arm"}] | unique_by([.name, .tag, .arch]) | {include: .}' "{{_sources}}"
 [private]
 ci-mirror-matrix:
-	@jq -c '[.[] | {name: .name, tag: .tag, source: .source, mirror_name: (.name + "-source")}] | {include: .}' "{{_sources}}"
+	@jq -c '[.[] | {name: .name, tag: .tag, source: .source, mirror_name: (.name + "-source")}] | unique_by([.name, .tag]) | {include: .}' "{{_sources}}"
 [private]
 ci-manifest-matrix:
-	@jq -c '[.[] | {name: (.name + "-staged"), tag: .tag}] | {include: .}' "{{_sources}}"
+	@jq -c '[.[] | {name: (.name + "-staged"), tag: .tag}] | unique_by([.name, .tag]) | {include: .}' "{{_sources}}"

--- a/staged-images/sources.json
+++ b/staged-images/sources.json
@@ -6,12 +6,6 @@
     "source": "quay.io/fedora/fedora-bootc:45@sha256:c03d2f5e8bc543c1371df582f40bc54b841a4bfa09749bac6b0137e37f74d665"
   },
   {
-    "_renovate": "datasource=docker depName=quay.io/fedora/fedora-bootc",
-    "name": "fedora-bootc",
-    "tag": "45",
-    "source": "quay.io/fedora/fedora-bootc:45@sha256:c03d2f5e8bc543c1371df582f40bc54b841a4bfa09749bac6b0137e37f74d665"
-  },
-  {
     "_renovate": "datasource=docker depName=quay.io/centos-bootc/centos-bootc",
     "name": "centos-bootc",
     "tag": "stream9",


### PR DESCRIPTION
Renovate PR #157 updated both fedora-bootc:43 and fedora-bootc:44 to fedora-bootc:45, creating duplicate entries in sources.json. The _field Justfile recipe returned multiple lines, embedding newlines in image references and breaking mirror/build/push steps.

Remove the duplicate, harden all jq lookups to error on duplicates, and add unique_by to matrix generation to prevent duplicate GHA jobs.

Also extend the Renovate "Disable Fedora OCI updates" rule to cover the custom.regex manager (sources.json), scoped to tag-only updates so digest pinning still works. This prevents Renovate from collapsing distinct Fedora version entries into duplicates again.

Switch chunkah image from quay.io/jlebon/chunkah to quay.io/coreos/chunkah.

Assisted-by: OpenCode (Claude Opus 4)