### PR TITLE
devenv: Add cargo-nextest

### DIFF
--- a/devenv/fetch-tools.py
+++ b/devenv/fetch-tools.py
@@ -72,6 +72,14 @@ TOOLS: dict[str, Tool] = {
         binary_path_fmt="jj",
         binary_name="jj",
     ),
+    "cargo-nextest": Tool(
+        repo="nextest-rs/nextest",
+        arch_map={"x86_64": "x86_64", "aarch64": "aarch64"},
+        tag_fmt="cargo-nextest-{version}",
+        tarball_fmt="cargo-nextest-{version}-{arch}-unknown-linux-gnu.tar.gz",
+        binary_path_fmt="cargo-nextest",
+        binary_name="cargo-nextest",
+    ),
 }
 
 

--- a/devenv/tool-versions.txt
+++ b/devenv/tool-versions.txt
@@ -10,3 +10,5 @@ scorecard@v5.4.0
 nushell@0.111.0
 # renovate: datasource=github-releases depName=jj-vcs/jj
 jj@0.40.0
+# renovate: datasource=github-releases depName=nextest-rs/nextest
+cargo-nextest@0.9.132

--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -214,6 +214,13 @@
       ],
       "enabled": false
     },
+    // nextest-rs/nextest is a monorepo with multiple crates released under
+    // different tag prefixes (cargo-nextest-*, nextest-runner-*, etc.).
+    // Extract only the cargo-nextest version from matching tags.
+    {
+      "matchPackageNames": ["nextest-rs/nextest"],
+      "extractVersion": "^cargo-nextest-(?<version>.*)$"
+    },
     // Rust nightly toolchain: use rust-release-channel versioning for nightly-YYYY-MM-DD format
     {
       "matchDatasources": ["custom.rust-nightly"],


### PR DESCRIPTION
I want to have this consistently as it's really useful.