### PR TITLE
devenv: Add Goose AI coding agent

### DIFF
--- a/devenv/README.md
+++ b/devenv/README.md
@@ -13,6 +13,7 @@ organization, especially bootc.
 - [bcvk](https://github.com/bootc-dev/bcvk/) to launch bootc VMs
 - [tmt](https://tmt.readthedocs.io/) since bootc testing requires it
 - [Kani](https://model-checking.github.io/kani/usage.html)
+- [Goose](https://github.com/block/goose) AI coding agent
 
 ## Base images
 

--- a/devenv/fetch-tools.py
+++ b/devenv/fetch-tools.py
@@ -80,6 +80,14 @@ TOOLS: dict[str, Tool] = {
         binary_path_fmt="cargo-nextest",
         binary_name="cargo-nextest",
     ),
+    "goose": Tool(
+        repo="block/goose",
+        arch_map={"x86_64": "x86_64", "aarch64": "aarch64"},
+        tag_fmt="{version}",  # version already includes 'v' prefix
+        tarball_fmt="goose-{arch}-unknown-linux-gnu.tar.gz",
+        binary_path_fmt="goose",
+        binary_name="goose",
+    ),
 }
 
 

--- a/devenv/tool-versions.txt
+++ b/devenv/tool-versions.txt
@@ -12,3 +12,5 @@ nushell@0.111.0
 jj@0.40.0
 # renovate: datasource=github-releases depName=nextest-rs/nextest
 cargo-nextest@0.9.132
+# renovate: datasource=github-releases depName=block/goose
+goose@v1.30.0


### PR DESCRIPTION
Adding Goose to the devenv image so it's available alongside OpenCode for AI-assisted development workflows.

Assisted-by: OpenCode (Claude Opus 4)