### PR TITLE
ci: Remove dangling openssf-scorecard.yml symlink

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -1,1 +1,0 @@
-../../common/.github/workflows/openssf-scorecard.yml


### PR DESCRIPTION
This was a symlink to common/.github/workflows/openssf-scorecard.yml,
which was removed in 7b39639 (Drop GHA from common/) when workflows
moved to bootc-dev/actions composite actions. The dangling symlink
has been causing "Invalid workflow file" errors on every push to main.

Assisted-by: OpenCode (Claude claude-opus-4-6)
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
