### PR TITLE
renovate: Fix cargo in-range updates being silently dropped

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -136,6 +136,20 @@
       "groupName": "Rust",
       "enabled": true
     },
+    // Restore cargo's default rangeStrategy for in-range updates.
+    //
+    // ":preserveSemverRanges" sets rangeStrategy=replace globally, which means
+    // Renovate only acts when a new version falls *outside* the existing range.
+    // For cargo deps like `tar = "0.4.43"` (i.e. ^0.4.43), patch releases such
+    // as 0.4.46 are in-range and would be silently ignored - Cargo.lock never
+    // gets updated. Restoring `update-lockfile` here makes Renovate bump
+    // Cargo.lock for in-range updates while still using `replace` for
+    // out-of-range ones (the same as cargo's native default behaviour).
+    {
+      "description": ["Restore update-lockfile rangeStrategy for cargo (overrides :preserveSemverRanges)"],
+      "matchManagers": ["cargo"],
+      "rangeStrategy": "update-lockfile"
+    },
     // Group Docker dependencies
     {
       "description": ["Docker dependencies"],


### PR DESCRIPTION
The global `:preserveSemverRanges` preset sets `rangeStrategy: replace` for all package managers. For cargo, this overrides its native default of `update-lockfile`, causing in-range patch bumps to produce empty `updates: []` — Renovate detects no change needed and generates no PR.

Concretely, `tar = "0.4.43"` (which Cargo treats as `^0.4.43`) will never be bumped in Cargo.lock when 0.4.44/0.4.45/0.4.46 release, because all of those satisfy the existing range and `replace` only acts when a version falls *outside* the range.

Restoring `update-lockfile` for the cargo manager makes Renovate update Cargo.lock for in-range releases (the same behaviour cargo's manager has by default) while still using `replace` for out-of-range updates.

Tested locally: dry-run with the broken config produced 4 flattened updates with `tar` absent; with the fix applied it produced 18 updates including `tar 0.4.45 → 0.4.46` correctly assigned to the Rust group.

Closes: #198

Assisted-by: OpenCode (Claude Sonnet 4.6)