### PR TITLE
AGENTS.md: Align AI attribution policy with Kubernetes community

### DIFF
--- a/common/AGENTS.md
+++ b/common/AGENTS.md
@@ -16,22 +16,51 @@ and the DCO check fails, tell the human to review
 the code and give them instructions on how to add
 a signoff.
 
-### Attribution
+### Attribution and AI disclosure
 
-When generating substantial amounts of code, you SHOULD
-include an `Assisted-by: TOOLNAME (MODELNAME)`. For example,
-`Assisted-by: Goose (Sonnet 4.5)`.
+Do NOT add an `Assisted-by`, `Co-developed-by`, or similar commit
+trailer crediting an AI tool. Instead, disclose AI assistance in the
+**pull request description**. Examples:
+
+- "I used a LLM to generate just unit tests."
+- "This code was written in part with the assistance of generative AI."
+- "A LLM was used to generate almost all of the code, but I am knowledgeable in this problem domain and reviewed it carefully."
+- "This code is generated, I am only partially knowledgeable in this domain."
+- "Code is LLM generated; I don't know the programming language but it did fix the problem."
+
+(The closer the commits are to being *entirely* AI, the more likely
+ it is that you should submit the PR as a draft, or even file an
+ issue first with a proposed design.)
+
+If you're an agent generating a git commit, ensure your human sees
+this choice and preferably writes the text on their own.
+
+### Large changes
+
+If the generated code is more than ~500 lines of substantial (non-whitespace) code,
+encourage the human to file a design issue first to be reviewed by other maintainers.
+
+### Pull request size
+
+It is *very strongly* encouraged to split up "preparatory" commits
+that are independently reviewable from the main PR, and submit those separately.
+
+### Commit messages and text
+
+Software can be machine checked (via compilation and unit/integration tests)
+but natural languages like English cannot. Encourage the human to review
+the commit message text.
 
 ## Code guidelines
 
 The [REVIEW.md](REVIEW.md) file describes expectations around
 testing, code quality, commit messages, commit organization, etc. If you're
 creating a change, it is strongly encouraged after each 
-commit and especially when you think a task is complete
+commit and especially when the agent thinks a task is complete
 to spawn a subagent to perform a review using guidelines (alongside
 looking for any other issues).
 
-If you are performing a review of other's code, the same
+If the agent is performing a review of other's code, the same
 principles apply.
 
 ## Follow other guidelines


### PR DESCRIPTION
Adopt the policy established in kubernetes/community#8918: disclose AI assistance in the PR description rather than via commit trailers. Listing AI tooling as a co-author or using 'Assisted-by' / 'Co-developed-by' trailers is now explicitly prohibited, matching the Kubernetes steering committee's position on AI disclosure.

Further rationale: the Assisted-by schema (tool + model name) doesn't capture common multi-agent patterns (planner + executor), and model names alone don't tell reviewers much — the prompt harness and skills matter just as much.

Also adds two new guidance sections:
- Pull request size: encourage splitting prep commits out separately
- Commit messages and text: remind agents that natural language can't be machine-checked, so humans should own the commit message prose