### PR TITLE
renovate: Update composefs crate names after cfsctl rename

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -225,7 +225,7 @@
       "matchManagers": ["cargo"],
       "matchPackageNames": [
         "composefs",
-        "cfsctl",
+        "composefs-ctl",
         "composefs-boot",
         "composefs-oci"
       ],


### PR DESCRIPTION
The cfsctl crate was renamed to composefs-ctl in
composefs/composefs-rs@4dd43a1 ("Cargo: rename crates to use
composefs- prefix"). Update the disabled package list accordingly.

Assisted-by: OpenCode (Claude Opus 4.6)
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
