### PR TITLE
renovate: Separate major Rust dependency bumps into individual PRs

### DIFF
--- a/renovate-shared-config.json
+++ b/renovate-shared-config.json
@@ -128,12 +128,17 @@
       "enabled": true
     },
     // Group Rust dependencies
+    //
+    // separateMultipleMajor splits each semver-breaking bump into its own PR
+    // so they can be reviewed/landed independently. Cargo versioning treats
+    // 0.x -> 0.y as major, so this covers both pre-1.0 and post-1.0 crates.
     {
       "description": ["Rust dependencies"],
       "matchManagers": [
         "cargo"
       ],
       "groupName": "Rust",
+      "separateMultipleMajor": true,
       "enabled": true
     },
     // Restore cargo's default rangeStrategy for in-range updates.


### PR DESCRIPTION
Having them all bundled means it's likely for updates to stall; it's clearer to address them individually.

Generated-by: AI