### PR TITLE
devenv: Add ostree to packages, such that ostree CLI is installed in …

### DIFF
--- a/devenv/packages-c10s.txt
+++ b/devenv/packages-c10s.txt
@@ -13,6 +13,9 @@ xorriso
 qemu-img
 libvirt-daemon-kvm
 
+# OSTree CLI (used by ostree integration tests)
+ostree
+
 # Testing framework
 tmt
 

--- a/devenv/packages-debian.txt
+++ b/devenv/packages-debian.txt
@@ -16,6 +16,9 @@ genisoimage
 qemu-utils
 libvirt-daemon-system
 
+# OSTree CLI (used by ostree integration tests)
+ostree
+
 # Filesystem verity utilities (composefs testing)
 fsverity
 

--- a/devenv/packages-ubuntu.txt
+++ b/devenv/packages-ubuntu.txt
@@ -15,6 +15,9 @@ genisoimage
 qemu-utils
 libvirt-daemon-system
 
+# OSTree CLI (used by ostree integration tests)
+ostree
+
 # Filesystem verity utilities (composefs testing)
 fsverity
 


### PR DESCRIPTION
The devenv images install libostree headers as a build dependency, such that bootc/ostree-ext compile
against libostree, but never install the `ostree` CLI itself.

crates/ostree-ext's integration test suite (tests/it/main.rs) shells
out to `ostree init`/`ostree commit` directly, so `cargo test -p
ostree-ext` fails inside a fresh devenv container with "command not
found: ostree" and a cascade of secondary failures from tests whose
fixture setup depends on it.

Adding `ostree` to the packages list, fixes this; makes the test pass out of the box.

Tested: cloned infra repo into running container, and built from there again and ran tests successfully

Created with the assistance of AI